### PR TITLE
Process nested template directives recursively

### DIFF
--- a/tests/runInitDirectives.test.js
+++ b/tests/runInitDirectives.test.js
@@ -1,0 +1,105 @@
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+const assert = require("assert");
+
+const sourcePath = path.resolve(__dirname, "../src/TXT2JSON.js");
+const source = fs.readFileSync(sourcePath, "utf8");
+
+function extractDeclaration(pattern) {
+  const match = pattern.exec(source);
+  if (!match) {
+    throw new Error("Failed to extract declaration for pattern: " + pattern);
+  }
+  return match[0];
+}
+
+function extractFunction(name) {
+  const marker = "function " + name + "(";
+  const start = source.indexOf(marker);
+  if (start === -1) {
+    throw new Error("Could not find function " + name);
+  }
+  const braceIndex = source.indexOf("{", start);
+  if (braceIndex === -1) {
+    throw new Error("Could not find opening brace for function " + name);
+  }
+
+  let depth = 0;
+  for (let i = braceIndex; i < source.length; i++) {
+    const char = source.charAt(i);
+    if (char === "{") {
+      depth++;
+    } else if (char === "}") {
+      depth--;
+      if (depth === 0) {
+        return source.slice(start, i + 1);
+      }
+    }
+  }
+
+  throw new Error("Failed to extract function body for " + name);
+}
+
+const context = {
+  _: require("../src/lib/lodash.js"),
+  templateError: function(message) {
+    throw new Error(message);
+  },
+  execInScope: function(code, scope) {
+    /* eslint no-with: 0 */
+    with (scope) { eval(code); }
+  }
+};
+
+vm.createContext(context);
+
+vm.runInContext(extractDeclaration(/var kindUL\s*=\s*"UL";/), context);
+vm.runInContext(extractFunction("installInitHelpers"), context);
+vm.runInContext(extractFunction("cloneTemplateTree"), context);
+vm.runInContext("runInitDirectives = " + extractFunction("runInitDirectives"), context);
+
+const kindUL = context.kindUL;
+
+function makeNode(text, parent) {
+  return {
+    kind: kindUL,
+    text: text,
+    children: [],
+    parent: parent
+  };
+}
+
+// Deep template with @init nested inside an extra node to exercise recursion.
+const deepTemplate = {
+  kind: kindUL,
+  text: "&Deep()",
+  children: [],
+  templates: {}
+};
+const wrapperNode = makeNode("- wrapper", deepTemplate);
+const initNode = makeNode("@init: $set('runs', ($get('runs') || 0) + 1)", wrapperNode);
+wrapperNode.children.push(initNode);
+deepTemplate.children.push(wrapperNode);
+
+// Register deep template inside another template to emulate nested definitions.
+const innerTemplate = {
+  kind: kindUL,
+  text: "&Inner()",
+  children: [],
+  templates: { Deep: deepTemplate }
+};
+deepTemplate.parent = innerTemplate;
+
+function expandDeep(scope) {
+  const clone = context.cloneTemplateTree(deepTemplate);
+  context.runInitDirectives(clone, scope);
+}
+
+const scope = {};
+expandDeep(scope);
+assert.strictEqual(scope.runs, 1, "First expansion should run @init once");
+expandDeep(scope);
+assert.strictEqual(scope.runs, 2, "Second expansion should run @init again");
+
+console.log("runInitDirectives nested template test passed.");


### PR DESCRIPTION
## Summary
- traverse template children and nested template definitions when running @init directives so initialization blocks inside nested templates execute and are removed consistently
- apply the same recursive traversal to anchor declarations to avoid leaving directive nodes in nested templates
- add a regression test that exercises an @init nested inside a template-in-template and verifies repeated expansions execute the initialization each time

## Testing
- node tests/runInitDirectives.test.js
- node tests/evalTemplateParameters.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dda9e3f564832fb3b77e8797e85661