### PR TITLE
Skip template expansion for null arguments

### DIFF
--- a/src/TXT2JSON.js
+++ b/src/TXT2JSON.js
@@ -3188,6 +3188,13 @@ var globalScope = (function(original) {
                         templateError("パラメータが不正です。\n\n" + e.message, node);
                     }
 
+                    if (parameters === null) {
+                        if (parent && parent.children) {
+                            parent.children[index] = null;
+                        }
+                        return;
+                    }
+
                     try {
                         // ★ 呼び出し地点のスコープを addTemplate に渡す
                         addTemplate(node, index, templateName, parameters, localScope);


### PR DESCRIPTION
## Summary
- avoid expanding template calls when their arguments evaluate to null

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dddaa01a10832fae21183e71b63f58