### PR TITLE
Skip reusing cached sheets with placeholder warnings

### DIFF
--- a/src/TXT2JSON.js
+++ b/src/TXT2JSON.js
@@ -1738,6 +1738,7 @@ _.forEach(noIdNodes, function(infos) {
 });
 
 var lastParsedRoot;
+var previousPlaceholderWarningsBySheet = loadPlaceholderWarningsCache();
 
 (function() {
     // 前回出力したJSONファイルがあれば読む
@@ -1841,16 +1842,16 @@ var srcTexts;   // XXX: root.id 用に保存しておく…
         }
 
         var parsedSheetNode = getParsedSheetNode(v);
+        var sheetNameForWarnings = getPlaceholderWarningSheetName(v);
 
         // srcHash が同じ sheetNode があれば、そのまま再利用
-        if (parsedSheetNode) {
+        if (shouldReuseParsedSheetNode(parsedSheetNode, sheetNameForWarnings)) {
             var info = {
                 index: index,
                 node: parsedSheetNode
             };
             parsedSheetNodeInfos.push(info);
-            var reusedSheetName = getPlaceholderWarningSheetName(v);
-            reusedSheetNames[reusedSheetName] = true;
+            reusedSheetNames[sheetNameForWarnings] = true;
             root.children[index] = null;
         }
     });
@@ -1944,7 +1945,6 @@ var PLACEHOLDER_WARNINGS_CACHE_FILENAME = "placeholder_warnings.json";
 
 var placeholderWarnings = [];
 var cachedPlaceholderWarningsMerged = false;
-var previousPlaceholderWarningsBySheet = loadPlaceholderWarningsCache();
 
 function getPlaceholderWarningSheetName(node) {
     if (!node) {
@@ -1964,6 +1964,21 @@ function getPlaceholderWarningSheetName(node) {
     }
 
     return "";
+}
+
+function shouldReuseParsedSheetNode(parsedSheetNode, sheetName) {
+    if (!parsedSheetNode) {
+        return false;
+    }
+
+    var sheetKey = sheetName || "";
+    if (previousPlaceholderWarningsBySheet &&
+        previousPlaceholderWarningsBySheet[sheetKey] &&
+        previousPlaceholderWarningsBySheet[sheetKey].length > 0) {
+        return false;
+    }
+
+    return true;
 }
 
 function getPlaceholderWarningFilePath(lineObj) {

--- a/tests/placeholderWarningsCacheReuse.test.js
+++ b/tests/placeholderWarningsCacheReuse.test.js
@@ -1,0 +1,81 @@
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+const assert = require("assert");
+
+const sourcePath = path.resolve(__dirname, "../src/TXT2JSON.js");
+const source = fs.readFileSync(sourcePath, "utf8");
+
+function extractFunction(name) {
+  const marker = "function " + name + "(";
+  const start = source.indexOf(marker);
+  if (start === -1) {
+    throw new Error("Could not find function " + name);
+  }
+  const braceIndex = source.indexOf("{", start);
+  if (braceIndex === -1) {
+    throw new Error("Could not find opening brace for function " + name);
+  }
+
+  let depth = 0;
+  for (let i = braceIndex; i < source.length; i++) {
+    const char = source.charAt(i);
+    if (char === "{") {
+      depth++;
+    } else if (char === "}") {
+      depth--;
+      if (depth === 0) {
+        return source.slice(start, i + 1);
+      }
+    }
+  }
+
+  throw new Error("Failed to extract function body for " + name);
+}
+
+const context = {
+  previousPlaceholderWarningsBySheet: {},
+  shouldReuseParsedSheetNode: null
+};
+
+vm.createContext(context);
+vm.runInContext(
+  "shouldReuseParsedSheetNode = " + extractFunction("shouldReuseParsedSheetNode"),
+  context
+);
+
+assert.strictEqual(
+  context.shouldReuseParsedSheetNode({ id: "node" }, "Sheet A"),
+  true,
+  "Sheets without cached warnings should be eligible for reuse"
+);
+
+context.previousPlaceholderWarningsBySheet = {
+  "Sheet A": [
+    { kind: "undefinedPlaceholder", message: "stale" }
+  ]
+};
+
+assert.strictEqual(
+  context.shouldReuseParsedSheetNode({ id: "node" }, "Sheet A"),
+  false,
+  "Sheets with cached placeholder warnings should be forced to reprocess"
+);
+
+context.previousPlaceholderWarningsBySheet = {
+  "Sheet A": []
+};
+
+assert.strictEqual(
+  context.shouldReuseParsedSheetNode({ id: "node" }, "Sheet A"),
+  true,
+  "Empty cached warning lists should not block reuse"
+);
+
+assert.strictEqual(
+  context.shouldReuseParsedSheetNode(null, "Sheet A"),
+  false,
+  "Missing parsed sheet nodes should not be reused"
+);
+
+console.log("placeholderWarningsCacheReuse tests passed.");


### PR DESCRIPTION
## Summary
- load the previous placeholder warning cache before the sheet reuse pass
- skip cached sheet reuse whenever the sheet had placeholder warnings and record reuse decisions via a helper
- add a regression test covering the new reuse guard logic

## Testing
- node tests/placeholderWarningsCacheReuse.test.js
- node tests/runInitDirectives.test.js
- node tests/evalTemplateParameters.test.js

------
https://chatgpt.com/codex/tasks/task_e_68de92f7e5fc832fa8f9d66a0e70ff5f