### PR TITLE
Fix placeholder warnings cache initialization

### DIFF
--- a/src/TXT2JSON.js
+++ b/src/TXT2JSON.js
@@ -1738,7 +1738,6 @@ _.forEach(noIdNodes, function(infos) {
 });
 
 var lastParsedRoot;
-var previousPlaceholderWarningsBySheet = loadPlaceholderWarningsCache();
 
 (function() {
     // 前回出力したJSONファイルがあれば読む
@@ -1943,6 +1942,7 @@ var PLACEHOLDER_WARN_DIALOG_LIMIT = 3;      // ダイアログに表示する警
 var PLACEHOLDER_WARNINGS_FILENAME = "placeholder_warnings.txt";
 var PLACEHOLDER_WARNINGS_CACHE_FILENAME = "placeholder_warnings.json";
 
+var previousPlaceholderWarningsBySheet = loadPlaceholderWarningsCache();
 var placeholderWarnings = [];
 var cachedPlaceholderWarningsMerged = false;
 

--- a/tests/placeholderWarningsCacheReuse.test.js
+++ b/tests/placeholderWarningsCacheReuse.test.js
@@ -33,6 +33,18 @@ function extractFunction(name) {
   throw new Error("Failed to extract function body for " + name);
 }
 
+function extractSection(startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  if (start === -1) {
+    throw new Error("Could not find start marker: " + startMarker);
+  }
+  const end = source.indexOf(endMarker, start);
+  if (end === -1) {
+    throw new Error("Could not find end marker: " + endMarker);
+  }
+  return source.slice(start, end);
+}
+
 const context = {
   previousPlaceholderWarningsBySheet: {},
   shouldReuseParsedSheetNode: null
@@ -76,6 +88,86 @@ assert.strictEqual(
   context.shouldReuseParsedSheetNode(null, "Sheet A"),
   false,
   "Missing parsed sheet nodes should not be reused"
+);
+
+const placeholderWarningsSection = extractSection(
+  "var PLACEHOLDER_WARN_ON_UNDEFINED",
+  "function mergeCachedPlaceholderWarnings"
+);
+
+const recordedPaths = {};
+
+const placeholderWarningsContext = {
+  outfilePath: path.join("C:", "project", "output", "result.json"),
+  fso: {
+    GetParentFolderName(filePath) {
+      recordedPaths.parent = filePath;
+      return path.dirname(filePath);
+    },
+    BuildPath(directory, fileName) {
+      recordedPaths.build = { directory, fileName };
+      return path.join(directory, fileName);
+    },
+    FileExists(filePath) {
+      recordedPaths.fileExists = filePath;
+      return false;
+    }
+  },
+  CL: {
+    readTextFileUTF8() {
+      throw new Error("Cache file should not be read when it does not exist");
+    }
+  },
+  _: {
+    assign: Object.assign,
+    some: (array, predicate) => array.some(predicate),
+    isArray: Array.isArray,
+    map: (array, iteratee) => array.map(iteratee),
+    pick: (object, keys) => {
+      const result = {};
+      for (const key of keys) {
+        if (Object.prototype.hasOwnProperty.call(object, key)) {
+          result[key] = object[key];
+        }
+      }
+      return result;
+    },
+    isString: value => typeof value === "string"
+  },
+  JSON
+};
+
+vm.createContext(placeholderWarningsContext);
+vm.runInContext(placeholderWarningsSection, placeholderWarningsContext);
+
+assert.deepStrictEqual(
+  recordedPaths,
+  {
+    parent: placeholderWarningsContext.outfilePath,
+    build: {
+      directory: path.dirname(placeholderWarningsContext.outfilePath),
+      fileName: "placeholder_warnings.json"
+    },
+    fileExists: path.join(
+      path.dirname(placeholderWarningsContext.outfilePath),
+      "placeholder_warnings.json"
+    )
+  },
+  "Placeholder warning cache should be resolved relative to the outfile using the expected filename"
+);
+
+assert.ok(
+  Object.prototype.hasOwnProperty.call(
+    placeholderWarningsContext,
+    "previousPlaceholderWarningsBySheet"
+  ),
+  "Placeholder warning cache map should be defined on the global context"
+);
+
+assert.deepStrictEqual(
+  Object.keys(placeholderWarningsContext.previousPlaceholderWarningsBySheet),
+  [],
+  "Missing cache files should result in an empty placeholder warning map"
 );
 
 console.log("placeholderWarningsCacheReuse tests passed.");


### PR DESCRIPTION
## Summary
- ensure the placeholder warnings cache filename is defined before loading cached warnings
- add coverage to confirm the cache loader resolves the expected filename and initializes cleanly

## Testing
- node tests/placeholderWarningsCacheReuse.test.js

------
https://chatgpt.com/codex/tasks/task_e_68deedc36f50832fb6bdef0ab121e744