### PR TITLE
Restore UTF-8 BOM for TXT2JSON.js

### DIFF
--- a/src/TXT2JSON.js
+++ b/src/TXT2JSON.js
@@ -1,4 +1,4 @@
-function alert(s) {
+﻿function alert(s) {
     WScript.Echo(s);
 }
 


### PR DESCRIPTION
## Summary
- restore the UTF-8 BOM at the top of TXT2JSON.js so Windows Script Host parses UTF-8 correctly

## Testing
- node tests/evalTemplateParameters.test.js
- node tests/placeholderWarningsCacheReuse.test.js
- node tests/runInitDirectives.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e00114cd48832f914154a9591afbcf