### PR TITLE
Prevent @init scope leakage into parent overlays

### DIFF
--- a/src/TXT2JSON.js
+++ b/src/TXT2JSON.js
@@ -3282,9 +3282,17 @@ var globalScope = (function(original) {
                     if (diffKey.charAt(0) === "$") continue;
                     if (typeof localScope[diffKey] === "function") continue;
 
-                    var isNew = !Object.prototype.hasOwnProperty.call(scopeSnapshot, diffKey);
-                    var changed = isNew ? true : (scopeSnapshot[diffKey] !== localScope[diffKey]);
-                    if (isNew || changed) {
+                    var existedBefore = Object.prototype.hasOwnProperty.call(scopeSnapshot, diffKey);
+                    var previousValue = existedBefore ? scopeSnapshot[diffKey] : undefined;
+
+                    if (!existedBefore && (diffKey in parentScope)) {
+                        existedBefore = true;
+                        previousValue = parentScope[diffKey];
+                    }
+
+                    if (!existedBefore) continue;
+
+                    if (previousValue !== localScope[diffKey]) {
                         parentScope[diffKey] = localScope[diffKey];
                     }
                 }


### PR DESCRIPTION
## Summary
- only write @init results back to ancestor scopes when the key already existed before execution
- add regression coverage ensuring branch-local variables stay in their _initScopeLayer overlays
- adjust existing tests to read branch state from _initScopeLayer and confirm inherited keys still propagate

## Testing
- node tests/runInitDirectives.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e008937540832fabc4bd469b2f205c