### PR TITLE
Fix template parameter evaluation to respect ancestor init scope

### DIFF
--- a/src/TXT2JSON.js
+++ b/src/TXT2JSON.js
@@ -2619,7 +2619,14 @@ var globalScope = (function(original) {
           _.defaults(referableParams, globalScope);
         }
         if (!_.isUndefined(currentParameters)) {
-            _.defaults(referableParams, currentParameters);
+            var scopeCursor = currentParameters;
+            while (scopeCursor && scopeCursor !== Object.prototype) {
+                var ownLayer = extractOwnScopeLayer(scopeCursor);
+                if (!_.isUndefined(ownLayer)) {
+                    _.defaults(referableParams, ownLayer);
+                }
+                scopeCursor = Object.getPrototypeOf(scopeCursor);
+            }
         }
         for (var parent = node.parent; !_.isUndefined(parent); parent = parent.parent) {
             if (!_.isUndefined(parent.params)) {


### PR DESCRIPTION
## Summary
- walk the current parameter scope prototype chain so values created by ancestor @init directives are available during template evaluation
- extend templateCallScope tests to cover ancestor-provided init values and ensure template calls expand without ReferenceError

## Testing
- node tests/templateCallScope.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e02d374e90832fa6f8b53a70dcebce