### PR TITLE
Include global scope in hash calculations

### DIFF
--- a/src/TXT2JSON.js
+++ b/src/TXT2JSON.js
@@ -318,7 +318,8 @@ function computeRootId() {
     // root.children を基に hash を求める
     //var k = JSON.stringify(root.children);
     var k = _.values(srcTexts).join("\n");
-    
+    k = prependGlobalScopeForHash(k);
+
     //var startTime = performance.now();
 //    var shaObj = new jsSHA("SHA-256", "TEXT", { encoding: "UTF8" });
 //    shaObj.update(k);
@@ -503,6 +504,19 @@ var confFileName = "conf.yml";
     }
 })();
 conf = readConfigFile(confFileName);
+
+// 一番上の階層の upper snake case なプロパティをシートから閲覧できるようにする
+var globalScope = (function(original) {
+    if (typeof original === "undefined") return {};
+
+    var keys = _.keys(original);
+    var filteredKeys = _.filter(keys, function(key) {
+        return /^[A-Z0-9_]+$/.test(key);
+    });
+    var filtered = _.pick(original, filteredKeys);
+
+    return filtered;
+})(conf);
 
 var entryFilePath = filePath;
 var entryProject = fso.GetParentFolderName(entryFilePath);
@@ -1794,6 +1808,39 @@ function getSHA1Hash(input) {
     return getHash(crypto, input);
 }
 
+function computeGlobalScopeHashPrefix() {
+    if (typeof globalScope === "undefined" || !globalScope) {
+        return "";
+    }
+
+    var keys = _.keys(globalScope);
+    if (!keys || keys.length === 0) {
+        return "";
+    }
+
+    keys.sort();
+
+    var normalized = {};
+    for (var i = 0; i < keys.length; i++) {
+        normalized[keys[i]] = globalScope[keys[i]];
+    }
+
+    return JSON.stringify(normalized);
+}
+
+function prependGlobalScopeForHash(text) {
+    var prefix = computeGlobalScopeHashPrefix();
+    if (!prefix) {
+        return text;
+    }
+
+    if (text === undefined || text === null || text === "") {
+        return prefix;
+    }
+
+    return prefix + "\n" + text;
+}
+
 // preprocess 後、 id 付与後のソーステキストをシートごとにhashで持っておく
 var parsedSheetNodeInfos = [];
 var reusedSheetNames = {};
@@ -1823,9 +1870,10 @@ var srcTexts;   // XXX: root.id 用に保存しておく…
 
     _.forEach(root.children, function(v, index) {
         var srcSheetText = result[v.id];
+        var hashTargetText = prependGlobalScopeForHash(srcSheetText);
 
         //v.srcHash = getSHA1Hash(srcSheetText);
-        v.srcHash = getMD5Hash(srcSheetText);
+        v.srcHash = getMD5Hash(hashTargetText);
 
         function getParsedSheetNode(sheetNode) {
             if (!lastParsedRoot) {
@@ -2569,20 +2617,6 @@ function evaluateInScope(expr, scope) {
     var func = new Function(keys.join(","), "return " + expr + ";");
     return func.apply(null, values);
 }
-
-// 一番上の階層の upper snake case なプロパティをシートから閲覧できるようにする
-var globalScope = (function(original) {
-    if (typeof original === "undefined") return {};
-
-    var keys = _.keys(original);
-    var filteredKeys = _.filter(keys, function(key) {
-        return /^[A-Z0-9_]+$/.test(key);
-    });
-    var filtered = _.pick(original, filteredKeys);
-
-    return filtered;
-})(conf);
-//printJSON(globalScope);
 
 // テンプレート埋め込み
 // まずはすべてのノードについて調べ、親に登録


### PR DESCRIPTION
## Summary
- prefix sheet hash inputs with the serialized globalScope values from conf
- ensure the overall root hash also incorporates the global scope prefix
- initialize the filtered global scope immediately after reading conf so hashing sees the scope values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0dbc3de7c832f9688f92d7eaebc66