### PR TITLE
Restore conf globals and support vars includes

### DIFF
--- a/src/TXT2JSON.js
+++ b/src/TXT2JSON.js
@@ -495,6 +495,53 @@ includePath.push(fso.GetParentFolderName(filePath));
 // FIXME: 廃止予定
 loadGlobalConfig();
 
+function readVarsFile(varsFileName) {
+    var varsFilePath = fso.BuildPath(fso.GetParentFolderName(filePath), varsFileName);
+    if (!fso.FileExists(varsFilePath)) {
+        return {};
+    }
+
+    var data = CL.readYAMLFile(varsFilePath);
+    if (!data) {
+        return {};
+    }
+
+    function processIncludeFiles(target, baseFile) {
+        if (!target || typeof target !== "object") {
+            return;
+        }
+
+        if (_.isUndefined(target.$include)) {
+            return;
+        }
+
+        var includeFiles = target.$include;
+        delete target.$include;
+
+        var baseDirectory = fso.GetParentFolderName(baseFile);
+        _.forEach(includeFiles, function(value) {
+            var includeFilePath;
+            if (typeof value === "string" && value.charAt(0) === "/") {
+                var rootDirectory = conf && conf.$rootDirectory;
+                if (!rootDirectory) {
+                    rootDirectory = baseDirectory;
+                }
+                includeFilePath = fso.BuildPath(rootDirectory, value.slice(1));
+            } else {
+                includeFilePath = fso.BuildPath(baseDirectory, value);
+            }
+
+            var includeData = CL.readYAMLFile(includeFilePath) || {};
+            processIncludeFiles(includeData, includeFilePath);
+            _.defaults(target, includeData);
+        });
+    }
+
+    processIncludeFiles(data, varsFilePath);
+
+    return data;
+}
+
 var confFileName = "conf.yml";
 (function() {
     var baseName = fso.GetBaseName(filePath);
@@ -506,7 +553,7 @@ var confFileName = "conf.yml";
 conf = readConfigFile(confFileName);
 
 // 一番上の階層の upper snake case なプロパティをシートから閲覧できるようにする
-var globalScope = (function(original) {
+var confGlobalScope = (function(original) {
     if (typeof original === "undefined") return {};
 
     var keys = _.keys(original);
@@ -517,6 +564,16 @@ var globalScope = (function(original) {
 
     return filtered;
 })(conf);
+
+var varsFileName = "vars.yml";
+(function() {
+    var baseName = fso.GetBaseName(filePath);
+    baseName = baseName.replace(/_index$/, "");
+    if (baseName != "index") {
+        varsFileName = baseName + "_" + varsFileName;
+    }
+})();
+var globalScope = _.extend({}, confGlobalScope, readVarsFile(varsFileName));
 
 var entryFilePath = filePath;
 var entryProject = fso.GetParentFolderName(entryFilePath);


### PR DESCRIPTION
## Summary
- recurse through $include entries in vars files and resolve /-prefixed paths from the project root
- merge upper-snake-case values from conf with vars.yml contents to build the global scope

## Testing
- node tests/addTemplateStringParameter.test.js
- node tests/placeholderWarningsCacheReuse.test.js
- node tests/runInitDirectives.test.js
- node tests/templateCallScope.test.js
- node tests/evalTemplateParameters.test.js *(fails: extractOwnScopeLayer is not defined in the test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68e274840f20832f97c7e8b0c2b16e30