### PR TITLE
Ensure template params remain visible when init scope exists

### DIFF
--- a/src/TXT2JSON.js
+++ b/src/TXT2JSON.js
@@ -2462,10 +2462,16 @@ function getInheritedScopeLayer(node) {
     if (!node) {
         return null;
     }
-    if (node._initScopeLayer) {
+    var hasParams = !!node.params;
+    var hasInitLayer = !!node._initScopeLayer;
+
+    if (hasParams && hasInitLayer) {
+        return _.assign({}, node.params, node._initScopeLayer);
+    }
+    if (hasInitLayer) {
         return node._initScopeLayer;
     }
-    if (node.params) {
+    if (hasParams) {
         return node.params;
     }
     return null;

--- a/tests/getInheritedScopeLayer.test.js
+++ b/tests/getInheritedScopeLayer.test.js
@@ -1,0 +1,66 @@
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+const assert = require("assert");
+
+const sourcePath = path.resolve(__dirname, "../src/TXT2JSON.js");
+const source = fs.readFileSync(sourcePath, "utf8");
+
+function extractFunction(name) {
+  const marker = "function " + name + "(";
+  const start = source.indexOf(marker);
+  if (start === -1) {
+    throw new Error("Could not find function " + name);
+  }
+  const braceIndex = source.indexOf("{", start);
+  if (braceIndex === -1) {
+    throw new Error("Could not find opening brace for function " + name);
+  }
+
+  let depth = 0;
+  for (let i = braceIndex; i < source.length; i++) {
+    const char = source.charAt(i);
+    if (char === "{") {
+      depth++;
+    } else if (char === "}") {
+      depth--;
+      if (depth === 0) {
+        return source.slice(start, i + 1);
+      }
+    }
+  }
+
+  throw new Error("Failed to extract function body for " + name);
+}
+
+const context = {
+  _: require("../src/lib/lodash.js")
+};
+
+vm.createContext(context);
+vm.runInContext(extractFunction("getInheritedScopeLayer"), context);
+
+const paramsLayer = { arr: ["e1", "e2"], foo: "bar" };
+const initLayer = { counter: 10 };
+
+const combined = context.getInheritedScopeLayer({
+  params: paramsLayer,
+  _initScopeLayer: initLayer
+});
+
+assert.ok(combined);
+assert.notStrictEqual(combined, paramsLayer, "Combined layer should not reuse params reference");
+assert.deepStrictEqual(combined.arr, paramsLayer.arr, "Params values should be preserved");
+assert.strictEqual(combined.foo, "bar", "Params keys should be kept");
+assert.strictEqual(combined.counter, 10, "Init layer keys should be merged");
+
+const onlyInit = context.getInheritedScopeLayer({ _initScopeLayer: initLayer });
+assert.strictEqual(onlyInit, initLayer, "Init layer alone should be returned directly");
+
+const onlyParams = context.getInheritedScopeLayer({ params: paramsLayer });
+assert.strictEqual(onlyParams, paramsLayer, "Params alone should be returned directly");
+
+const none = context.getInheritedScopeLayer(null);
+assert.strictEqual(none, null, "Null node should yield null layer");
+
+console.log("getInheritedScopeLayer merges params with init scope.");


### PR DESCRIPTION
## Summary
- merge init scope overlays with template parameters so data anchors remain accessible during inline expansions
- add a unit test covering scope layer combination behavior

## Testing
- node tests/getInheritedScopeLayer.test.js
- node tests/templateCallScope.test.js
- node tests/runInitDirectives.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e3ccf5c62c832f903219b279dde6fa